### PR TITLE
Remove old sign-up from navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
 					<li><a href="https://join.slack.com/t/codevid-19/shared_invite/zt-cs8amank-jg7vUQeSUgX7K9cM9WZMfQ">JOIN THE SLACK</a></li>
 					<li><a href="#rules">Rules + info + FAQ</a></li>
 					<li><a href="https://docs.google.com/document/d/e/2PACX-1vRGokbfY-E2Dh8CK1HoQMxQbvmyj-9DW9O1vLqXSP3NySQY8_sjvRAJmhFzAkgRhT9vGVtb8Kpx20RI/pub">Code of Conduct</a></li>
-					<li><a href="https://docs.google.com/forms/d/e/1FAIpQLScliKxuyOHypNiOhq9zbv97VYOIQ-vNfFE0eVXG3eRELP12eA/viewform?usp=sf_link">Team sign-up</a></li>
 					<li><a href="#mailing-list">Mailing List</a></li>
 				</ul>
 			</nav>


### PR DESCRIPTION
- It was still sending users to Google Forms
- Let's use Join the Fight to direct people where they need to be