### PR TITLE
Remove old sign-up link from navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,12 +53,6 @@
                 >Code of Conduct</a
               >
             </li>
-            <li>
-              <a
-                href="https://docs.google.com/forms/d/e/1FAIpQLScliKxuyOHypNiOhq9zbv97VYOIQ-vNfFE0eVXG3eRELP12eA/viewform?usp=sf_link"
-                >Team sign-up</a
-              >
-            </li>
             <li><a href="#mailing-list">Mailing List</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
- It was still sending users to Google Forms
- Let's use Join the Fight to direct people where they need to be