### PR TITLE
Only allow emails for contact when submitting apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,8 +298,8 @@
                       included in the app itself)
                     </li>
                     <li>
-                      A point of contact (e.g. email, FindCollabs user, Slack
-                      user) for organizers and judges to follow-up with
+                      An email address that judges can use to follow up with
+                      the team should they have questions or concerns
                     </li>
                     <li>
                       For open-source projects, we encourage a link to the

--- a/index.html
+++ b/index.html
@@ -299,7 +299,8 @@
                     </li>
                     <li>
                       An email address that judges can use to follow up with
-                      the team should they have questions or concerns
+                      the team should they have questions or concerns. This
+                      will not be shared with the public, or with voters.
                     </li>
                     <li>
                       For open-source projects, we encourage a link to the

--- a/index.html
+++ b/index.html
@@ -290,12 +290,12 @@
                     <li>
                       A link to your working app (whether that's a FindCollabs
                       link, the website URL, or a TestFlight/Google Play opt-in
-                      URL)
+                      URL).
                     </li>
-                    <li>A screenshot and/or video of your app</li>
+                    <li>A screenshot and/or video of your app.</li>
                     <li>
                       Instructions for interacting with your app (if not
-                      included in the app itself)
+                      included in the app itself).
                     </li>
                     <li>
                       An email address that judges can use to follow up with
@@ -305,7 +305,7 @@
                     <li>
                       For open-source projects, we encourage a link to the
                       source code repository (e.g. GitHub, GitLab, Bitbucket,
-                      etc.)
+                      etc.).
                     </li>
                   </ul>
                 </li>


### PR DESCRIPTION
I'm working on the submission form right now. Allowing other contact options is too confusing, also given the number of projects joining it's likely we'll need to limit contact points to keep things organized should issues arise.

This limits us to just emails.