### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM ruby:2
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    # Verify git, process tools installed
+    && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # Install ruby-debug-ide and debase
+    && gem install ruby-debug-ide \
+    && gem install debase \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ruby-2
+{
+	"name": "DES RFCs",
+	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Use 'appPort' to create a container with published ports. If the port isn't working, be sure
+	// your server accepts connections from all interfaces (0.0.0.0 or '*'), not just localhost.
+	"appPort": [ 4000 ],
+
+	// Uncomment the next line to run commands after the container is created.
+	"postCreateCommand": "bundle install",
+
+	// Uncomment the next line to have VS Code connect as an existing non-root user in the container. 
+	// On Linux, by default, the container user's UID/GID will be updated to match your local user. See
+	// https://aka.ms/vscode-remote/containers/non-root for details on adding a non-root user if none exist.
+	// "remoteUser": "vscode",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"rebornix.Ruby",
+		"vscodevim.vim"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
 # codevid19.com
 
-This uses Jeykll with Github Pages plugins, so that content can be quickly published and served as a Github Page. To build locally you'll need to install Ruby 2.1+.
-
-With Ruby 2.1+ installed, you'll want to install dependencies using bundler.
-
-    bundle install
-
-From this point you can build and serve the site using:
-
-    bundle exec jekyll serve -H 0.0.0.0 -p 4000
-
-This will serve the site at:
-
-    http://localhost:4000
+TODO

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # codevid19.com
-Codevid Website
+
+This uses Jeykll with Github Pages plugins, so that content can be quickly published and served as a Github Page. To build locally you'll need to install Ruby 2.1+.
+
+With Ruby 2.1+ installed, you'll want to install dependencies using bundler.
+
+    bundle install
+
+From this point you can build and serve the site using:
+
+    bundle exec jekyll serve -H 0.0.0.0 -p 4000
+
+This will serve the site at:
+
+    http://localhost:4000


### PR DESCRIPTION
This sets up a version of Ruby that's compatible with running `jekyll`.

It doesn't include `node` so I'll do a seperate PR if we start needing that.