### PR TITLE
Fix FAQ link to rules

### DIFF
--- a/policies/faq.md
+++ b/policies/faq.md
@@ -46,7 +46,7 @@ This hackathon is free to enter and participate in! We thank our sponsors for su
 
 #### Okay, so what's the catch?
 
-Participants and volunteers must abide by and uphold the [Code of Conduct](code-of-conduct.html), [Rules](#rules) and generally be an upstanding human being.
+Participants and volunteers must abide by and uphold the [Code of Conduct](code-of-conduct.html), [Rules]({{ '/#rules-and-faq' | relative_url }}) and generally be an upstanding human being.
 
 #### If I see organizers give out a time/deadline, what time zone is it in?
 


### PR DESCRIPTION
Takes them to the new section on our landing page.  Anybody can give this a LGTM and merge this one if I don't get to it.

We don't typically merge each others' PRs, but I'll allow it for this one since it's so tiny.