### PR TITLE
Remove redundant blog post title

### DIFF
--- a/_posts/2020-04-07-charity-shop-exchange.md
+++ b/_posts/2020-04-07-charity-shop-exchange.md
@@ -3,8 +3,6 @@ author: John
 title: Charity Shop Exchange
 ---
 
-# Charity Shop Exchange
-
 <span class="image right">
     <img src="/images/blog/charity-shop-exchange.png" alt="Charity Shop Exchange">
 </span>


### PR DESCRIPTION
@johnny-newton normally I'd just make a commit on `master` for something this small, but I thought I'd bring it to your attention as Jekyll automatically creates a title for you when you fill in the metadata (called [Front Matter](https://jekyllrb.com/docs/front-matter/)) at the top:

```
---
author: John
title: Charity Shop Exchange
---
```

![image](https://user-images.githubusercontent.com/6334517/78958763-46d8e200-7aa6-11ea-9e86-434661cab4aa.png)

And if you're curious about tagging and categorizing, Jekyll posts [have those too](https://jekyllrb.com/docs/posts/#categories-and-tags).