### PR TITLE
Allow Jekyll to generate excerpts by moving images

### DIFF
--- a/_posts/2020-04-05-hello.md
+++ b/_posts/2020-04-05-hello.md
@@ -3,14 +3,14 @@ title: Hello World!
 author: John
 ---
 
+In case you have just joined us, CODEVID-19 was launched on March 16, 2020 in Edmonton, Canada. It has been truly awe-inspiring to see how the hackathon has brought together developers, designers, passionate creators, and experts from public health and emergency management from around the globe.
+
 <span class="image right">
     <img src="/images/blog/edmonton-skyline.jpg" alt="Edmonton Skyline">
     <small>
         <a href="https://www.flickr.com/photos/iqremix/42276507674">Edmonton Summer Cityscape</a> by <a href="https://www.flickr.com/photos/iqremix/">IQRemix</a>, used under <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>
     </small>
 </span>
-
-In case you have just joined us, CODEVID-19 was launched on March 16, 2020 in Edmonton, Canada. It has been truly awe-inspiring to see how the hackathon has brought together developers, designers, passionate creators, and experts from public health and emergency management from around the globe.
 
 It turns out that when you put more than 1600 intensely energized and focused people, from over 40 countries into a Slack channel, amazing things happen!
 

--- a/_posts/2020-04-07-charity-shop-exchange.md
+++ b/_posts/2020-04-07-charity-shop-exchange.md
@@ -3,11 +3,11 @@ author: John
 title: Charity Shop Exchange
 ---
 
+A large helping of thank-you to [Blake Prouty](https://twitter.com/BlakeNthaniel) for giving us insight into his team’s [Charity Shop Exchange](https://charityshopexchange.com) project. Blake is an unlikely hockey fan who hails from South Dakota, and cheers for the Calgary Flames. This is no place for hockey rivalry, so without further ado here are his thoughts on the project.
+
 <span class="image right">
     <img src="/images/blog/charity-shop-exchange.png" alt="Charity Shop Exchange">
 </span>
-
-A large helping of thank-you to [Blake Prouty](https://twitter.com/BlakeNthaniel) for giving us insight into his team’s [Charity Shop Exchange](https://charityshopexchange.com) project. Blake is an unlikely hockey fan who hails from South Dakota, and cheers for the Calgary Flames. This is no place for hockey rivalry, so without further ado here are his thoughts on the project.
 
 **Where did your idea come from and what problem are you trying to address?**
 


### PR DESCRIPTION
This is temporary but allows us to link to our blog listing page without needing to mess with its layout for now.  I'm learning that Jekyll auto-generates excerpts based on the first paragraph, but it doesn't seem to like HTML images being the "first paragraph" much.

## Before / After
### Blog Listing
![image](https://user-images.githubusercontent.com/6334517/78961526-ff0a8880-7aae-11ea-9232-e950abdcb904.png)
![image](https://user-images.githubusercontent.com/6334517/78961542-10539500-7aaf-11ea-86e0-7e9c5dce9382.png)

### Hello World
![image](https://user-images.githubusercontent.com/6334517/78962076-b9e75600-7ab0-11ea-9e7a-90a2c23d0519.png)
![image](https://user-images.githubusercontent.com/6334517/78961867-05e5cb00-7ab0-11ea-9023-b3d0f89887bf.png)

### Charity Exchange
![image](https://user-images.githubusercontent.com/6334517/78961533-06ca2d00-7aaf-11ea-84b1-993583d98ea9.png)
![image](https://user-images.githubusercontent.com/6334517/78961558-1c3f5700-7aaf-11ea-8085-be193f11570b.png)

## Another Proposal
I understand we can also define our own `excerpt` in a front matter variable, but that feels like an extra effort at times and I don't know if we want to enforce that.

![image](https://user-images.githubusercontent.com/6334517/78961760-c8813d80-7aaf-11ea-99ad-893717eb7164.png)
![image](https://user-images.githubusercontent.com/6334517/78961725-af788c80-7aaf-11ea-90e3-d908a9cbf0d0.png)
