### PR TITLE
Increase readabilty of foreground text

### DIFF
--- a/_sass/libs/_vars.scss
+++ b/_sass/libs/_vars.scss
@@ -43,7 +43,7 @@ $font: (
 $palette: (
   bg: #312450,
   bg-alt: darken(#312450, 5),
-  fg: rgba(255, 255, 255, 0.55),
+  fg: rgba(255, 255, 255, 0.67),
   fg-bold: #ffffff,
   fg-light: rgba(255, 255, 255, 0.35),
   border: rgba(255, 255, 255, 0.15),


### PR DESCRIPTION
Slight bump in opacity from 55% to 67%.  I want to eventually turn the blog section's background into white because my eyes get tired faster when reading long-form on a darker background like this, but this also helps increase readability across all content at the moment.

![image](https://user-images.githubusercontent.com/6334517/78963041-5f9bc480-7ab3-11ea-8798-b7e34912851d.png)
![image](https://user-images.githubusercontent.com/6334517/78963094-9a056180-7ab3-11ea-82a7-7ac5c9fe4e40.png)

Might be tricky to see in the screenshot, I suggest clicking them and viewing them in full-size.