### PR TITLE
Make default headers stick to top on scroll

### DIFF
--- a/_sass/layout/_header.scss
+++ b/_sass/layout/_header.scss
@@ -11,6 +11,10 @@
   background-color: _palette(accent1);
   cursor: default;
   padding: 1.75em 2em;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0px;
+  z-index: 999;
 
   > .title {
     border: 0;


### PR DESCRIPTION
- Works on mobile/tablet too
- Affects all page layouts that use `default`
- Doesn't affect homepage's left nav as it uses `base`

![image](https://user-images.githubusercontent.com/6334517/78963582-2d8b6200-7ab5-11ea-9030-0160af3fcb86.png)

I was originally going to create a "Go to top" button, but I despise fixed-position elements and think this is just better than forcing a user to click twice to see our nav.