### PR TITLE
Reflow landing, move Join the Fight out

### DIFF
--- a/_posts/2020-04-05-hello.md
+++ b/_posts/2020-04-05-hello.md
@@ -25,6 +25,6 @@ Projects compete in four problem areas:
 
 Each project is evaluated on effectiveness, accessibility, and impact.
 
-We would like to thank everyone for their boundless energy, expansive knowledge, and technical expertise. Together, we'll make a difference in the world! If you haven't already signed up, you can [join the fight](https://codevid19.com/#join-the-fight) and more directly from our [website](https://codevid19.com)!
+We would like to thank everyone for their boundless energy, expansive knowledge, and technical expertise. Together, we'll make a difference in the world! If you haven't already signed up, you can [join the fight](https://codevid19.com/join-the-fight.html) and more directly from our [website](https://codevid19.com)!
 
 On behalf of the CODEVID-19 organizers, the many people who have graciously stepped up to lend a hand, and our sponsors, we wish you the best and good luck!

--- a/index.html
+++ b/index.html
@@ -254,14 +254,22 @@ description: >
       <section id="become-a-sponsor">
         <h3>Become a Sponsor</h3>
         <p>
-          For prizes and resources like cloud computing, we need sponsors and
-          partners! For information on tiers and perks, see our
-          <a href="pdfs/SponsorshipPackage.pdf">sponsorship package.</a>
+          We are looking for sponsors who can offer prizes and resources such as
+          cloud computing. We thank all current and prospective sponsors for
+          their interest!
         </p>
         <ul class="actions">
           <li>
-            <a href="mailto:sponsors@codevid19.com" class="button scrolly"
-              >Get in touch</a
+            <a
+              href="pdfs/SponsorshipPackage.pdf"
+              target="_blank"
+              class="button icon solid fa-external-link-alt"
+              >View Sponsorship Package</a
+            >
+          </li>
+          <li>
+            <a href="mailto:sponsors@codevid19.com" class="button"
+              >Get in Touch</a
             >
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@ description: >
             aware of that when adding things here. Add it somewhere they can
             see-->
         <li><a href="#intro">Welcome</a></li>
-        <li><a href="#join-the-fight">Join the Fight</a></li>
         <li>
           <a href="#rules-and-faq">Rules & FAQ</a>
         </li>
@@ -54,119 +53,14 @@ description: >
       </p>
       <ul class="actions">
         <li>
-          <a href="#join-the-fight" class="button scrolly">Join the Fight</a>
+          <a href="join-the-fight" class="button">Join the Fight</a>
+        </li>
+        <li>
+          <a href="#become-a-sponsor" class="button scrolly"
+            >Become a Sponsor</a
+          >
         </li>
       </ul>
-    </div>
-  </section>
-
-  <!-- Join the fight -->
-  <section id="join-the-fight" class="wrapper style1 fade-up">
-    <div class="inner">
-      <h2>Join The Fight!</h2>
-      <p>
-        The purpose of the hackathon ultimately isn’t to win prizes, it’s to
-        build useful apps that people can use to manage and survive during the
-        COVID-19 pandemic. What started in Edmonton, Canada as a discussion
-        amongst developers on the Dev Edmonton Society Slack has exploded into a
-        global initiative to improve people's quality of live and fight the
-        pandemic.
-      </p>
-      <p>
-        With participants in over 10 countries around world, it's a growing
-        movement. Anyone interested in helping out is invited to join the fight
-        and get involved!
-      </p>
-      <section>
-        <h3>Developers & Designers</h3>
-        <p>
-          If you're not ready to start a team, or are just looking to share
-          feedback and ideas, then the Slack is for you. Join to find a team,
-          brainstorm app ideas, and chat with your team mates. Anyone is free to
-          start a new channel too.
-        </p>
-        <ul class="actions">
-          <li>
-            <a
-              href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
-              class="button scrolly"
-              >Join Slack</a
-            >
-          </li>
-        </ul>
-        <p>
-          Once you're ready: Start or join a project on the FindCollabs
-          hackathon! You can change team members, and the app you're building at
-          any time. You could even enter a new app each week!
-        </p>
-        <p>
-          Remember to read the rules and
-          <a href="{{ '/policies/code-of-conduct.html' | relative_url }}">
-            Code of Conduct</a
-          >
-          first. If you have questions reach out to
-          <a href="mailto:contact@codevid19.com">contact@codevid19.com</a>
-        </p>
-        <ul class="actions">
-          <li>
-            <a
-              href="https://findcollabs.com/hackathon/codevid-19-isp21fkqtjupchx7kjed"
-              class="button scrolly"
-              >Start a Project</a
-            >
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h3>Problem Experts</h3>
-        <p>
-          Are you a healthcare expert? Emergency management professional?
-          Senior? Parent? You're who we're building these apps for so we want to
-          hear from you!
-        </p>
-        <p>
-          Join our Slack and head to the #brainstorming channel where you can
-          share app ideas and problems, maybe even join a team to help them
-          solve it!
-        </p>
-        <ul class="actions">
-          <li>
-            <a
-              href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
-              class="button scrolly"
-              >Join Slack</a
-            >
-          </li>
-        </ul>
-        <p>
-          We're also looking for expert judges to help evaluate the entries at
-          the end of April. If you're interested in judging and want to know
-          more reach out by email at
-          <a href="mailto:judges@codevid19.com">judges@codevid19.com</a>
-        </p>
-        <ul class="actions">
-          <li>
-            <a href="mailto:judges@codevid19.com" class="button scrolly"
-              >Become a Judge</a
-            >
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h3>Sponsors & Partners</h3>
-        <p>
-          From prizes and resources like cloud computing, we need sponsors and
-          partners! If this is you please reach out! See our Sponsorship package
-          <a href="pdfs/SponsorshipPackage.pdf">here</a>
-        </p>
-        <ul class="actions">
-          <li>
-            <a href="mailto:sponsors@codevid19.com" class="button scrolly"
-              >Become a Sponsor</a
-            >
-          </li>
-        </ul>
-      </section>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -251,7 +251,13 @@ description: >
           </section>
         </div>
       </section>
-      <section id="become-a-sponsor">
+
+      <!--
+        Anchoring here works around interaction between fade animation start
+        and smooth scrolling
+      -->
+      <hr id="become-a-sponsor" />
+      <section>
         <h3>Become a Sponsor</h3>
         <p>
           We are looking for sponsors who can offer prizes and resources such as

--- a/index.html
+++ b/index.html
@@ -19,14 +19,14 @@ description: >
         <li>
           <a href="#rules-and-faq">Rules & FAQ</a>
         </li>
-        <li><a href="#links">Links &amp; Resources</a></li>
-        <li><a href="#mailing-list">Mailing List</a></li>
+        <li><a href="#links">Links & Resources</a></li>
         <li>
           <a href="#sponsors">Sponsors</a>
         </li>
         <li>
           <a href="#organizers">Organizers</a>
         </li>
+        <li><a href="#mailing-list">Mailing List</a></li>
       </ul>
     </nav>
   </div>
@@ -64,6 +64,7 @@ description: >
     </div>
   </section>
 
+  <!-- Rules & FAQ -->
   <section id="rules-and-faq" class="wrapper style2 fade-up">
     <div class="inner">
       <h2>Rules</h2>
@@ -115,9 +116,10 @@ description: >
     </div>
   </section>
 
+  <!-- Links & Resources -->
   <section id="links" class="wrapper style3 fade-up">
     <div class="inner">
-      <h2>Links and Resources</h2>
+      <h2>Links & Resources</h2>
       <div class="features">
         <section>
           <span class="icon solid major fa-code"></span>
@@ -183,8 +185,196 @@ description: >
     </div>
   </section>
 
+  <!-- Sponsors -->
+  <section id="sponsors" class="wrapper style1 fade-up">
+    <div class="inner">
+      <h2>Sponsors</h2>
+      <section>
+        <h3>Gold</h3>
+        <p></p>
+        <div class="row aln-center gtr-150">
+          <section class="special sponsor-logo">
+            <a href="https://www.amii.ca/" class="sponsor-link">
+              <img
+                src="./images/sponsors/Amii-white-logo.svg"
+                class="image gold-logo"
+                alt="Amii"
+              />
+            </a>
+          </section>
+        </div>
+
+        <!-- <h3>Silver</h3> -->
+
+        <h3>Bronze</h3>
+        <p></p>
+
+        <div class="row aln-center gtr-150">
+          <section class="special sponsor-logo">
+            <a href="https://torontojs.com/" class="sponsor-link">
+              <img
+                src="./images/sponsors/torontoJS.png"
+                class="image bronze-logo"
+                alt="TorontoJS"
+              />
+            </a>
+          </section>
+
+          <section class="special sponsor-logo">
+            <a href="https://clubhouse.io" class="sponsor-link">
+              <img
+                src="./images/sponsors/Clubhouse_PrimaryLogo_White.svg"
+                class="image bronze-logo"
+                alt="Clubhouse.io"
+              />
+            </a>
+          </section>
+
+          <section class="special sponsor-logo">
+            <a href="https://www.kickbyte.com/" class="sponsor-link">
+              <img
+                src="./images/sponsors/kickbyte-logo-white.svg"
+                class="image bronze-logo"
+                alt="Kickbyte"
+              />
+            </a>
+          </section>
+
+          <section class="special sponsor-logo">
+            <a href="https://fauna.com/" class="sponsor-link">
+              <img
+                src="./images/sponsors/Fauna-logo-white.png"
+                class="image bronze-logo"
+                alt="Fauna"
+              />
+            </a>
+          </section>
+        </div>
+      </section>
+      <section id="become-a-sponsor">
+        <h3>Become a Sponsor</h3>
+        <p>
+          For prizes and resources like cloud computing, we need sponsors and
+          partners! For information on tiers and perks, see our
+          <a href="pdfs/SponsorshipPackage.pdf">sponsorship package.</a>
+        </p>
+        <ul class="actions">
+          <li>
+            <a href="mailto:sponsors@codevid19.com" class="button scrolly"
+              >Get in touch</a
+            >
+          </li>
+        </ul>
+      </section>
+    </div>
+  </section>
+
+  <!-- Organizers -->
+  <section id="organizers" class="wrapper style2 fade-up">
+    <div class="inner">
+      <h2>Organizers</h2>
+      <p>
+        Your team of volunteers who are working hard to make this event happen!
+      </p>
+    </div>
+    <div class="row aln-center gtr-150">
+      <section class="special">
+        <img
+          src="./images/DES.png"
+          class="image profile-pic"
+          alt="Dev Edmonton Society"
+        />
+        <h3>Dev Edmonton Society</h3>
+        <p><a href="https://github.com/devedmonton">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/John.jpg"
+          class="image profile-pic"
+          alt="John Newton"
+        />
+        <h3>John Newton</h3>
+        <p>
+          <a href="https://www.linkedin.com/in/johnnynewton/">LinkedIn</a>
+        </p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Kevin.jpg"
+          class="image profile-pic"
+          alt="Kevin de Haan"
+        />
+        <h3>Kevin de Haan</h3>
+        <p><a href="https://github.com/kdehaan">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Mandy.jfif"
+          class="image profile-pic"
+          alt="Mandy Meindersma"
+        />
+        <h3>Mandy Meindersma</h3>
+        <p><a href="https://github.com/MandyMeindersma">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Mark.png"
+          class="image profile-pic"
+          alt="Mark Bennett"
+        />
+        <h3>Mark Bennett</h3>
+        <p><a href="https://github.com/markbennett">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Matthew.jpg"
+          class="image profile-pic"
+          alt="Matthew Mihok"
+        />
+        <h3>Matthew Mihok</h3>
+        <p><a href="https://github.com/mihok">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Adam.png"
+          class="image profile-pic"
+          alt="Adam El-Masri"
+        />
+        <h3>Adam El-Masri</h3>
+        <p><a href="https://github.com/adamelmasri">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/Patricia.jfif"
+          class="image profile-pic"
+          alt="Patricia Borlongan"
+        />
+        <h3>Patricia Borlongan</h3>
+        <p><a href="https://github.com/pborlongan">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/djphan.jpg"
+          class="image profile-pic"
+          alt="Dan Phan"
+        />
+        <h3>Dan Phan</h3>
+        <p><a href="https://github.com/djphan">GitHub</a></p>
+      </section>
+      <section class="special">
+        <img
+          src="./images/looking.jpg"
+          class="image profile-pic"
+          alt="We're looking!"
+        />
+        <h3>Volunteers Wanted!</h3>
+        <p><a href="#links">Send us a Slack message!</a></p>
+      </section>
+    </div>
+  </section>
+
   <!-- Mailing List -->
-  <section id="mailing-list" class="wrapper style1 fade-up">
+  <section id="mailing-list" class="wrapper style3 fade-up">
     <div class="inner">
       <h2>Mailing List</h2>
       <p>
@@ -330,190 +520,6 @@ description: >
           </ul>
         </section>
       </div>
-    </div>
-  </section>
-
-  <!-- sponsors -->
-  <section id="sponsors" class="wrapper style2 fade-up">
-    <div class="inner">
-      <h2>Sponsors</h2>
-      <h3>Gold</h3>
-      <p></p>
-      <div class="row aln-center gtr-150">
-        <section class="special sponsor-logo">
-          <a href="https://www.amii.ca/" class="sponsor-link">
-            <img
-              src="./images/sponsors/Amii-white-logo.svg"
-              class="image gold-logo"
-              alt="Amii"
-            />
-          </a>
-        </section>
-      </div>
-      <!-- <h3>Silver</h3> -->
-      <h3>Bronze</h3>
-      <p></p>
-
-      <div class="row aln-center gtr-150">
-        <section class="special sponsor-logo">
-          <a href="https://torontojs.com/" class="sponsor-link">
-            <img
-              src="./images/sponsors/torontoJS.png"
-              class="image bronze-logo"
-              alt="TorontoJS"
-            />
-          </a>
-        </section>
-
-        <section class="special sponsor-logo">
-          <a href="https://clubhouse.io" class="sponsor-link">
-            <img
-              src="./images/sponsors/Clubhouse_PrimaryLogo_White.svg"
-              class="image bronze-logo"
-              alt="Clubhouse.io"
-            />
-          </a>
-        </section>
-
-        <section class="special sponsor-logo">
-          <a href="https://www.kickbyte.com/" class="sponsor-link">
-            <img
-              src="./images/sponsors/kickbyte-logo-white.svg"
-              class="image bronze-logo"
-              alt="Kickbyte"
-            />
-          </a>
-        </section>
-
-        <section class="special sponsor-logo">
-          <a href="https://fauna.com/" class="sponsor-link">
-            <img
-              src="./images/sponsors/Fauna-logo-white.png"
-              class="image bronze-logo"
-              alt="Fauna"
-            />
-          </a>
-        </section>
-      </div>
-      <section>
-        <h3>Become a Sponsor</h3>
-        <p>
-          For prizes and resources like cloud computing, we need sponsors and
-          partners! For information on tiers and perks, see our
-          <a href="pdfs/SponsorshipPackage.pdf">sponsorship package.</a>
-        </p>
-        <ul class="actions">
-          <li>
-            <a href="mailto:sponsors@codevid19.com" class="button scrolly"
-              >Get in touch</a
-            >
-          </li>
-        </ul>
-      </section>
-    </div>
-  </section>
-
-  <!-- organizers -->
-  <section id="organizers" class="wrapper style3 fade-up">
-    <div class="inner">
-      <h2>Organizers</h2>
-      <p>
-        Your team of volunteers who are working hard to make this event happen!
-      </p>
-    </div>
-    <div class="row aln-center gtr-150">
-      <section class="special">
-        <img
-          src="./images/DES.png"
-          class="image profile-pic"
-          alt="Dev Edmonton Society"
-        />
-        <h3>Dev Edmonton Society</h3>
-        <p><a href="https://github.com/devedmonton">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/John.jpg"
-          class="image profile-pic"
-          alt="John Newton"
-        />
-        <h3>John Newton</h3>
-        <p>
-          <a href="https://www.linkedin.com/in/johnnynewton/">LinkedIn</a>
-        </p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Kevin.jpg"
-          class="image profile-pic"
-          alt="Kevin de Haan"
-        />
-        <h3>Kevin de Haan</h3>
-        <p><a href="https://github.com/kdehaan">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Mandy.jfif"
-          class="image profile-pic"
-          alt="Mandy Meindersma"
-        />
-        <h3>Mandy Meindersma</h3>
-        <p><a href="https://github.com/MandyMeindersma">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Mark.png"
-          class="image profile-pic"
-          alt="Mark Bennett"
-        />
-        <h3>Mark Bennett</h3>
-        <p><a href="https://github.com/markbennett">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Matthew.jpg"
-          class="image profile-pic"
-          alt="Matthew Mihok"
-        />
-        <h3>Matthew Mihok</h3>
-        <p><a href="https://github.com/mihok">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Adam.png"
-          class="image profile-pic"
-          alt="Adam El-Masri"
-        />
-        <h3>Adam El-Masri</h3>
-        <p><a href="https://github.com/adamelmasri">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/Patricia.jfif"
-          class="image profile-pic"
-          alt="Patricia Borlongan"
-        />
-        <h3>Patricia Borlongan</h3>
-        <p><a href="https://github.com/pborlongan">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/djphan.jpg"
-          class="image profile-pic"
-          alt="Dan Phan"
-        />
-        <h3>Dan Phan</h3>
-        <p><a href="https://github.com/djphan">GitHub</a></p>
-      </section>
-      <section class="special">
-        <img
-          src="./images/looking.jpg"
-          class="image profile-pic"
-          alt="We're looking!"
-        />
-        <h3>Volunteers Wanted!</h3>
-        <p><a href="#links">Send us a Slack message!</a></p>
-      </section>
     </div>
   </section>
 </div>

--- a/join-the-fight.html
+++ b/join-the-fight.html
@@ -1,0 +1,109 @@
+---
+layout: default
+title: Join the Fight - CODEVID-19
+description: >
+  Calling all technologists, subject matter experts, media personnel, and more!   We invite all who are interested to participate.
+---
+
+<h2>We Need Your Help!</h2>
+<p>
+  The purpose of the hackathon ultimately isn’t to win prizes, it’s to build
+  useful apps that people can use to manage and survive during the COVID-19
+  pandemic. What started in Edmonton, Canada as a discussion amongst developers
+  on the Dev Edmonton Society Slack has exploded into a global initiative to
+  improve people's quality of live and fight the pandemic.
+</p>
+<p>
+  With participants in over 10 countries around world, it's a growing movement.
+  Anyone interested in helping out is invited to join the fight and get
+  involved!
+</p>
+<section>
+  <h3>Developers & Designers</h3>
+  <p>
+    If you're not ready to start a team, or are just looking to share feedback
+    and ideas, then the Slack is for you. Join to find a team, brainstorm app
+    ideas, and chat with your team mates. Anyone is free to start a new channel
+    too.
+  </p>
+  <ul class="actions">
+    <li>
+      <a
+        href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
+        class="button scrolly"
+        >Join Slack</a
+      >
+    </li>
+  </ul>
+  <p>
+    Once you're ready: Start or join a project on the FindCollabs hackathon! You
+    can change team members, and the app you're building at any time. You could
+    even enter a new app each week!
+  </p>
+  <p>
+    Remember to read the rules and
+    <a href="{{ '/policies/code-of-conduct.html' | relative_url }}">
+      Code of Conduct</a
+    >
+    first. If you have questions reach out to
+    <a href="mailto:contact@codevid19.com">contact@codevid19.com</a>
+  </p>
+  <ul class="actions">
+    <li>
+      <a
+        href="https://findcollabs.com/hackathon/codevid-19-isp21fkqtjupchx7kjed"
+        class="button scrolly"
+        >Start a Project</a
+      >
+    </li>
+  </ul>
+</section>
+<section>
+  <h3>Problem Experts</h3>
+  <p>
+    Are you a healthcare expert? Emergency management professional? Senior?
+    Parent? You're who we're building these apps for so we want to hear from
+    you!
+  </p>
+  <p>
+    Join our Slack and head to the #brainstorming channel where you can share
+    app ideas and problems, maybe even join a team to help them solve it!
+  </p>
+  <ul class="actions">
+    <li>
+      <a
+        href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
+        class="button scrolly"
+        >Join Slack</a
+      >
+    </li>
+  </ul>
+  <p>
+    We're also looking for expert judges to help evaluate the entries at the end
+    of April. If you're interested in judging and want to know more reach out by
+    email at
+    <a href="mailto:judges@codevid19.com">judges@codevid19.com</a>
+  </p>
+  <ul class="actions">
+    <li>
+      <a href="mailto:judges@codevid19.com" class="button scrolly"
+        >Become a Judge</a
+      >
+    </li>
+  </ul>
+</section>
+<section>
+  <h3>Sponsors & Partners</h3>
+  <p>
+    From prizes and resources like cloud computing, we need sponsors and
+    partners! If this is you please reach out! See our Sponsorship package
+    <a href="pdfs/SponsorshipPackage.pdf">here</a>
+  </p>
+  <ul class="actions">
+    <li>
+      <a href="mailto:sponsors@codevid19.com" class="button scrolly"
+        >Become a Sponsor</a
+      >
+    </li>
+  </ul>
+</section>

--- a/join-the-fight.html
+++ b/join-the-fight.html
@@ -2,7 +2,8 @@
 layout: default
 title: Join the Fight - CODEVID-19
 description: >
-  Calling all technologists, subject matter experts, media personnel, and more!   We invite all who are interested to participate.
+  Calling all technologists, subject matter experts, media personnel, and more!
+  We invite all who are interested to participate.
 ---
 
 <h2>We Need Your Help!</h2>
@@ -96,14 +97,19 @@ description: >
   <h3>Sponsors & Partners</h3>
   <p>
     From prizes and resources like cloud computing, we need sponsors and
-    partners! If this is you please reach out! See our Sponsorship package
-    <a href="pdfs/SponsorshipPackage.pdf">here</a>
+    partners! If this is you, we invite you to reach out.
   </p>
   <ul class="actions">
     <li>
-      <a href="mailto:sponsors@codevid19.com" class="button scrolly"
-        >Become a Sponsor</a
+      <a
+        href="pdfs/SponsorshipPackage.pdf"
+        target="_blank"
+        class="button icon solid fa-external-link-alt"
+        >View Sponsorship Package</a
       >
+    </li>
+    <li>
+      <a href="mailto:sponsors@codevid19.com" class="button">Get in Touch</a>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
- Move Join the Fight to a separate page
- Moved Mailing List to the bottom
- Updated background styles so they alternate
- Sponsor CTA tweaked

I made effectively zero change to the Join the Fight copy, besides renaming the first header (because our `default` template already creates a title for us).

## Before and Afters
### Hero
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/6334517/79057213-0a2ef700-7c1c-11ea-85c9-9beb31f8b07c.png">
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/6334517/79057217-16b34f80-7c1c-11ea-9540-c33ebc14904d.png">

## Join the Fight
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/6334517/79057259-86c1d580-7c1c-11ea-8104-ba10b0561690.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6334517/79057224-2fbc0080-7c1c-11ea-9518-1b087fee7911.png">

## Become a Sponsor CTA
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/6334517/79057260-90e3d400-7c1c-11ea-853d-af3762387d38.png">
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/6334517/79057244-5f6b0880-7c1c-11ea-9728-2170281df181.png">
