### PR TITLE
Suppress warnings when building locally

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-bundle exec jekyll serve -H 0.0.0.0 -p 4000
+bundle exec jekyll serve -H 0.0.0.0 -p 4000 2>&1 | grep -E -v 'deprecated|GitHub Metadata'


### PR DESCRIPTION
`jekyll build` is used when deploying to production, so no impact there.  We don't use GitHub Pages Ruby commands either, so we can suppress its warning too.

I have learned that Ruby 2.7 is [more performant](https://github.com/jekyll/jekyll/issues/7947#issuecomment-568918687), and that we [can't use Jekyll 4.0 yet](https://github.com/github/pages-gem/issues/651#issuecomment-581069671), so I favoured suppressing warnings.  I'm not a fan of suppressing warnings, but I can corroborate [this user's findings](https://github.com/mmistakes/minimal-mistakes/issues/2458#issuecomment-603001315) in that setting environment variables inside the container and using the one-liner trick don't work with `bundle` commands. 😞

Plus, we're of the mindset of keeping our toolchains light, so the likelihood of us installing something where Ruby warnings are useful is unlikely.

### Before
<img width="964" alt="image" src="https://user-images.githubusercontent.com/6334517/79062541-7fb8b880-7c58-11ea-9013-c09379fcdcd0.png">

### After
<img width="452" alt="image" src="https://user-images.githubusercontent.com/6334517/79062544-89dab700-7c58-11ea-807a-3c88d1a47b0c.png">
