### PR TITLE
Improve action button flex-wrap behaviour

### DIFF
--- a/_sass/components/_actions.scss
+++ b/_sass/components/_actions.scss
@@ -9,12 +9,15 @@
 ul.actions {
   @include vendor("display", "flex");
   cursor: default;
+  flex-wrap: wrap;
   list-style: none;
-  margin-left: (_size(element-margin) * -0.5);
+  margin: (_size(element-margin) * -0.5) (_size(element-margin) * -0.5)
+    (_size(element-margin) * 0.5) (_size(element-margin) * -0.5);
   padding-left: 0;
+  padding-top: (_size(element-margin) * 0.5);
 
   li {
-    padding: 0 0 0 (_size(element-margin) * 0.5);
+    padding: 0 0 (_size(element-margin) * 0.5) (_size(element-margin) * 0.5);
     vertical-align: middle;
   }
 
@@ -49,7 +52,6 @@ ul.actions {
     li {
       @include vendor("flex-grow", "1");
       @include vendor("flex-shrink", "1");
-      width: 100%;
 
       > * {
         width: 100%;


### PR DESCRIPTION
- On tablet/mobile, horizontal action buttons weren't wrapping
- Adding a simple flex-wrap was not enough, guttering needed to change

## Using `<ul class="actions">`
<img width="663" alt="image" src="https://user-images.githubusercontent.com/6334517/79246745-d5e35280-7e36-11ea-8024-8469b4e37f0d.png">

## Using `<ul class="actions fit">`
<img width="686" alt="image" src="https://user-images.githubusercontent.com/6334517/79245913-02e33580-7e36-11ea-8761-9354d99ac45c.png">

**NOTE:** Blog link not part of this PR, see #78 for that.  I just cherry-picked it locally to have something to test with.

This is the fix for a bug documented [here](https://github.com/devedmonton/codevid19.com/pull/78#issuecomment-613503725) in #78.  I used [elements.html](https://codevid19.com/elements.html) as my manual regression test and compared bullet lists and action buttons (they both use `<ul>...</ul>` under the hood) with my `localhost:4000` version.  They looked identical.  Same comparison can be done with [Netlify](https://deploy-preview-81--codevid-19-staging.netlify.com/elements.html).