### PR TITLE
Add cookie consent banner

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,7 +8,10 @@
   <head>
     <title>{{ page.title | default: site.title }}</title>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="{{ '/public/favicon.ico' | relative_url }}" />
+    <link
+      rel="shortcut icon"
+      href="{{ '/public/favicon.ico' | relative_url }}"
+    />
     <link rel="manifest" href="{{ '/public/manifest.json' | relative_url }}" />
     <meta
       name="viewport"
@@ -61,8 +64,19 @@
             <a href="https://devedmonton.com">DES</a> with &hearts;.
           </li>
           <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          <li><a href="{{ '/policies/privacy-policy.html' | relative_url }}">Privacy Policy</a></li>
-          <li>License: <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC Attrib-ShareAlike 4.0</a>.</li>
+          <li>
+            <a href="{{ '/policies/privacy-policy.html' | relative_url }}"
+              >Privacy Policy</a
+            >
+          </li>
+          <li>
+            License:
+            <a
+              rel="license"
+              href="http://creativecommons.org/licenses/by-sa/4.0/"
+              >CC Attrib-ShareAlike 4.0</a
+            >.
+          </li>
         </ul>
       </div>
     </footer>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -30,18 +30,45 @@
       property="og:description"
       content="{{ page.description | default: site.description }}"
     />
+
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
     <noscript>
       <link
         rel="stylesheet"
         href="{{ '/assets/css/noscript.css' | relative_url }}"
     /></noscript>
+
+    <!-- Cookie Consent by https://www.TermsFeed.com -->
+    <script
+      type="text/javascript"
+      src="//www.termsfeed.com/public/cookie-consent/3.0.0/cookie-consent.js"
+    ></script>
+    <script type="text/javascript">
+      document.addEventListener("DOMContentLoaded", function () {
+        cookieconsent.run({
+          notice_banner_type: "simple",
+          consent_type: "express",
+          palette: "dark",
+          language: "en",
+          website_name: "CODEVID-19",
+          cookies_policy_url: "https://codevid19.com/privacy-policy#usage-data",
+        });
+      });
+    </script>
+
+    <noscript
+      >Cookie Consent by
+      <a href="https://www.TermsFeed.com/">TermsFeed Generator</a></noscript
+    >
+
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async
+      type="text/plain"
+      cookie-consent="tracking"
       src="https://www.googletagmanager.com/gtag/js?id=UA-160846790-1"
     ></script>
-    <script>
+    <script type="text/plain" cookie-consent="tracking">
       window.dataLayer = window.dataLayer || [];
       function gtag() {
         dataLayer.push(arguments);

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -53,6 +53,12 @@
           website_name: "CODEVID-19",
           cookies_policy_url: "https://codevid19.com/privacy-policy#usage-data",
         });
+
+        var consentText = $(".cc_dialog_text")[0];
+        consentText.textContent = consentText.textContent.replace(
+          ", to show you personalized content and targeted ads",
+          ""
+        );
       });
     </script>
 

--- a/_sass/components/_cookie_consent.scss
+++ b/_sass/components/_cookie_consent.scss
@@ -1,0 +1,79 @@
+/* TermsFeed Cookie Consent overrides */
+
+// Pretty gnarly abuse of !important because TermsFeed injects their CSS after
+// DOM load and at the bottom.
+
+.cc_css_reboot {
+  font-family: _font(family) !important;
+
+  button {
+    border-radius: 3em !important;
+    padding: 0 0.75em !important;
+  }
+
+  select {
+    padding: 0 _size(element-height) 0 1em !important;
+  }
+}
+
+.cc_dialog {
+  &.simple {
+    max-width: unset !important;
+    width: 100%;
+  }
+
+  .cc_dialog_text {
+    font-size: 0.8em !important;
+  }
+
+  button {
+    letter-spacing: normal;
+  }
+}
+
+.cookie-consent-preferences-overlay
+  .cookie-consent-preferences-dialog
+  .cc_cp_container {
+  .cc_cp_footer {
+    .cc_cp_f_powered_by {
+      font-size: 0.8em !important;
+    }
+
+    .cc_cp_f_save button {
+      letter-spacing: normal;
+    }
+  }
+
+  .cc_cp_m_content .cc_cp_m_content_entry p {
+    font-size: 0.8em !important;
+  }
+}
+
+.dark.cc_dialog {
+  button {
+    &.cc_b_ok {
+      background-color: _palette(accent1) !important;
+    }
+
+    &.cc_b_cp {
+      background-color: transparent !important;
+    }
+  }
+}
+
+.dark.cookie-consent-preferences-overlay
+  .cookie-consent-preferences-dialog
+  .cc_cp_container {
+  .cc_cp_head .cc_cp_head_lang_selector select {
+    color: white !important;
+  }
+
+  .cc_cp_footer .cc_cp_f_save button {
+    background-color: _palette(accent1) !important;
+  }
+}
+
+div.cc_css_reboot {
+  // Having to override _their_ !important is extra-nasty
+  padding: _size(element-margin) !important;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -71,6 +71,7 @@
 @import "components/spotlights";
 @import "components/table";
 @import "components/wrapper";
+@import "components/cookie_consent";
 
 // Layout.
 


### PR DESCRIPTION
Thanks to [TermsFeed](https://www.termsfeed.com/cookie-consent/) once again, now we're compliant with GDPR and join the increasing number of websites with this _wonderful_ block of legal text.  I had to do some fairly gnarly SASS overrides to fix some of their broken styles, while also removing mention of personalized content and serving of ads (because we don't do any of that).  For brevity, I opted not to screenshot additional fixes to some styling after you click "Change my Preferences" and are shown a dialog.

[ch543]

# Caveats
- I verified that Google Analytics does get downloaded and initialized if you accept all cookies, but I don't have the faintest clue how to confirm whether it still works once we deploy it to production.  @kdehaan @johnny-newton I may need your help verifying this on GA's side.
- I'm also a NoScript and uBlock Origin user, so testing out analytics is not in my skill set 😅 

## Default
<img src="https://user-images.githubusercontent.com/6334517/79280745-6721eb80-7e6e-11ea-8be4-8c97597dc072.png" height=320 />  <img src="https://user-images.githubusercontent.com/6334517/79280776-71dc8080-7e6e-11ea-8321-52738049f1a7.png" height=320 />

## Overrides
<img src="https://user-images.githubusercontent.com/6334517/79280807-89b40480-7e6e-11ea-989c-5c84ea4cc3c5.png" height=320 />  <img src="https://user-images.githubusercontent.com/6334517/79280815-8de02200-7e6e-11ea-90d8-57e76d1d05bf.png" height=320 />