### PR TITLE
Prevent TypeError by checking before replacing consent text

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -55,10 +55,13 @@
         });
 
         var consentText = $(".cc_dialog_text")[0];
-        consentText.textContent = consentText.textContent.replace(
-          ", to show you personalized content and targeted ads",
-          ""
-        );
+
+        if (consentText && consentText.textContent) {
+          consentText.textContent = consentText.textContent.replace(
+            ", to show you personalized content and targeted ads",
+            ""
+          );
+        }
       });
     </script>
 


### PR DESCRIPTION
If you visit our page after accepting the cookie disclaimer, a `TypeError` occurs:
![Screen Shot 2020-04-14 at 8 47 30 PM](https://user-images.githubusercontent.com/6334517/79293627-75cdca00-7e91-11ea-9dd9-988e4f94ed08.png)

I fixed this by checking for truthiness before attempting the text replacement hack.