### PR TITLE
Nitpicking grammar and HTML

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,9 +9,9 @@ description: CODEVID-19 is a global hackathon to build useful apps that people c
   <nav>
     <ul>
       <li><a href="{{ '/' | relative_url }}">Home</a></li>
-      <li><a href="{{ '/policies/rules.html' | relative_url }}">Rules</a></li>
-      <li><a href="{{ '/policies/submissions.html' | relative_url }}">Submit Your Project</a></li>
-      <li><a href="{{ '/policies/faq.html' | relative_url }}">FAQ</a></li>
+      <li><a href="{{ '/policies/rules' | relative_url }}">Rules</a></li>
+      <li><a href="{{ '/policies/submissions' | relative_url }}">Submit Your Project</a></li>
+      <li><a href="{{ '/policies/faq' | relative_url }}">FAQ</a></li>
     </ul>
   </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ description: >
           >
         </li>
         <li>
-          <a href="https://forms.gle/ApPc1ckSNdrSxWTH6" class="button scrolly"
+          <a href="https://forms.gle/ApPc1ckSNdrSxWTH6" class="button"
             >Become a Judge</a
           >
         </li>
@@ -179,7 +179,7 @@ description: >
 
         <ul class="actions">
           <li>
-            <a href="/resources" class="button scrolly"
+            <a href="/resources" class="button"
               >Free resources and other offers</a
             >
           </li>

--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@ description: >
 
       <ol>
         <li><strong>Supporting Crisis Response</strong></li>
-        <li><strong>Understanding The Pandemic</strong></li>
+        <li><strong>Understanding the Pandemic</strong></li>
         <li><strong>Social Distancing & Isolation</strong></li>
-        <li><strong>Scarcity & The Economy</strong></li>
+        <li><strong>Scarcity & the Economy</strong></li>
       </ol>
 
       <p>

--- a/join-the-fight.html
+++ b/join-the-fight.html
@@ -31,7 +31,7 @@ description: >
     <li>
       <a
         href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
-        class="button scrolly"
+        class="button"
         >Join Slack</a
       >
     </li>
@@ -53,7 +53,7 @@ description: >
     <li>
       <a
         href="https://findcollabs.com/hackathon/codevid-19-isp21fkqtjupchx7kjed"
-        class="button scrolly"
+        class="button"
         >Start a Project</a
       >
     </li>
@@ -74,7 +74,7 @@ description: >
     <li>
       <a
         href="https://join.slack.com/t/codevid-19/shared_invite/zt-dcs1sv47-TXkkSa8vg0uAq5wv1SMnMQ"
-        class="button scrolly"
+        class="button"
         >Join Slack</a
       >
     </li>
@@ -87,7 +87,7 @@ description: >
   </p>
   <ul class="actions">
     <li>
-      <a href="mailto:judges@codevid19.com" class="button scrolly"
+      <a href="mailto:judges@codevid19.com" class="button"
         >Become a Judge</a
       >
     </li>

--- a/policies/rules.md
+++ b/policies/rules.md
@@ -27,9 +27,9 @@ The CODEVID-19 Hackathon is divided into two phases. Weekly prizes are awarded u
 Projects compete in four problem areas, and are evaluated on effectiveness, accessibility, and impact. We're passionate about improving the quality of life for people during and after the COVID-19 Pandemic by addressing the following problems:
 
 1. Supporting Crisis Response
-2. Understanding The Pandemic
+2. Understanding the Pandemic
 3. Social Distancing & Isolation
-4. Scarcity & The Economy
+4. Scarcity & the Economy
 
 ### Supporting Crisis Response
 
@@ -37,7 +37,7 @@ First responders, healthcare workers and emergency response managers are on the 
 
 Examples of apps in this category might include services to crowd source reporting of crisis information, using machine learning and data science to quickly identify problems to be addressed, or allow more efficient distribution of health care and emergency resources.
 
-### Understanding The Pandemic
+### Understanding the Pandemic
 
 How can we better understand the current state of the pandemic and make informed decisions about the future? How do we evaluate and trust the information around us?
 
@@ -51,7 +51,7 @@ How do we limit the impact and costs associated with Social Isolation and Distan
 
 Apps in this category might help connect people together, identify people in distress, facilitate remote working, on assist parents and educators continue classes.
 
-### Scarcity & The Economy
+### Scarcity & the Economy
 
 Economics is the study of scarcity, and during the pandemic it's a struggle to understand the situation and how to most effectively use limited resources to maximum effect.
 
@@ -133,7 +133,7 @@ By participating, participants agree to give organizers permission to contact th
 
 Participants understand that by withdrawing their consent to communicate with organizers they will be putting themselves, their team, and their project at a competitive disadvantage. Organizers cannot be held responsible for participants receiving information supplied via email or Slack. It's a participant's responsibility to regularly check the website or Slack for updates should they choose to withdraw consent.
 
-# Competing In Other Events
+# Competing in Other Events
 
 Participation in other hackathons and events during this period does not disqualify you from participating in CODEVID-19. As long as you, your project and your team meet CODEVID-19's full rules and code of conduct, you're welcome to participate in CODEVID-19 and submit your project.
 


### PR DESCRIPTION
- Lowercase "in", "the", in headings
- Use clean URLs because it's pretty sweet that Jekyll supports them.  Also allows VS Code to `Ctrl+click` to files more often.
- Removed `scrolly` class misuse.  It's only needed if you are linking to an anchor on the same page.