### PR TITLE
Add link to problem area, condense Submissions even further

### DIFF
--- a/policies/rules.md
+++ b/policies/rules.md
@@ -89,7 +89,7 @@ Teams have until **Thursday, April 30th at 23:59 UTC** to submit their projects 
 
 ## Problem Area Prizes (8 in total)
 
-Decided by a panel of expert judges, there are **8 prizes** up for grabs: 1 to a winner and 1 to a runner-up team in **each** of the **four problem areas**. Judging begins shortly after submission has closed. Although we aim to have judging wrap up within one week, we reserve the right to give our judges more time to evaluate the submissions.
+Decided by a panel of expert judges, there are **8 prizes** up for grabs: 1 to a winner and 1 to a runner-up team in **each** of the **four [problem areas](rules#the-problems)**. Judging begins shortly after submission has closed. Although we aim to have judging wrap up within one week, we reserve the right to give our judges more time to evaluate the submissions.
 
 ## Popular Choice Prize (1 in total)
 

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -13,7 +13,7 @@ The following are all **required** unless stated otherwise.
 
 1. URL to your working app (the website, or a TestFlight/Google Play opt-in link).
 1. URL to a screenshot we can share with voters and the media.
-1. The [CODEVID-19 problem](rules.html#the-problems) you're addressing.
+1. The [CODEVID-19 problem](rules#the-problems) you're addressing.
 1. Short description/pitch for your app we can share on Twitter and social media (140 characters or less)
 1. Long description/pitch for your app we can use to describe your app to voters, judges, and the media.
 1. Instructions for interacting with your app (if not included in the app itself).

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -3,14 +3,11 @@ layout: default
 title: Submitting Your Project
 ---
 
-# Submission Details
-
-Before proceeding, ensure that you have read and understood the **[full rules!](rules.html)**
-
 ## Deliverables
 
 The following are all **required** unless stated otherwise.
 
+1. You have read and understood the **[full rules](rules)**.
 1. URL to your working app (the website, or a TestFlight/Google Play opt-in link).
 1. URL to a screenshot we can share with voters and the media.
 1. The [CODEVID-19 problem](rules#the-problems) you're addressing.


### PR DESCRIPTION
Made the Submission page even more condensed and quick to the chase.  This was work I already had done a couple days ago but wanted to wait until #74 was merged.