### PR TITLE
Allow icons in feature buttons

### DIFF
--- a/_sass/components/_features.scss
+++ b/_sass/components/_features.scss
@@ -28,7 +28,7 @@
       border-left: solid 1px _palette(border);
     }
 
-    .icon {
+    > .icon {
       @include vendor(
         "transition",
         (
@@ -46,7 +46,7 @@
 
     @for $i from 1 through _misc(max-features) {
       &:nth-child(#{$i}) {
-        .icon {
+        > .icon {
           @include vendor(
             "transition-delay",
             "#{(_duration(transition) * 0.75 * $i)}"
@@ -58,7 +58,7 @@
 
   &.inactive {
     section {
-      .icon {
+      > .icon {
         @include vendor("transform", "scale(0.5)");
         opacity: 0;
       }
@@ -83,7 +83,7 @@
     section {
       @include padding(2em, 1.5em, (0.5em, 0, 0, 4em));
 
-      .icon {
+      > .icon {
         left: 1.5em;
         top: 2em;
       }
@@ -94,7 +94,7 @@
     section {
       @include padding(2em, 1.5em, (0, 0, 0, 0));
 
-      .icon {
+      > .icon {
         left: 0;
         position: relative;
         top: 0;


### PR DESCRIPTION
Make CSS selector only apply absolute-position on immediate icon (i.e. the big icon in the screenshots below).  Sadly the deploy preview doesn't have an example of this yet, currently working on a few in the Join the Fight refactor branch.

I verified manually by comparing elements.html to Production.

### Before
![image](https://user-images.githubusercontent.com/6334517/79487310-4d4ee880-7fd5-11ea-8e9c-b6700cbee62d.png)

### After
![image](https://user-images.githubusercontent.com/6334517/79487411-6d7ea780-7fd5-11ea-81e2-59f8014e522f.png)
