### PR TITLE
Surroung the blog post title in quotes ("")

### DIFF
--- a/_posts/2020-04-21-week5-winner.md
+++ b/_posts/2020-04-21-week5-winner.md
@@ -1,15 +1,14 @@
 ---
 author: John
-title: Congratulations Week Five Winner: Open Marketplace!
+title: "Congratulations Week Five Winner: Open Marketplace!"
 ---
 
 Our week five winner [Open Marketplace](https://open-marketplace-applications.github.io/marketplace/), is leveraging the open source and nonprofit model used by Wikipedia to improve Covid-19 response.
 
 <img src="/images/blog/open marketplace.jpg" alt="Open Marketplace" style="max-width: 100%;">
 
-Open Marketplace brings sellers, buyers, and delivery providers together on a platform controlled by a city not a single company. Open Marketplace is an open source and decentralized technology for the present and the future. Currently, platforms attempt to dominate a whole market. A platform with monopoly status can create its own rules, set prices, and collect data to manipulate consumers. Our team builds community driven, open source applications. Open Marketplace's development team is funded via donation and open grants. This funding model is used by Wikipedia, Linux, and Mozilla: current exemplars of production-ready nonprofit software. Our product enables communities to sell, share and communicate without a middleman, and includes privacy protection by design.  Open Marketplace applications: an app store for smart cities!
+Open Marketplace brings sellers, buyers, and delivery providers together on a platform controlled by a city not a single company. Open Marketplace is an open source and decentralized technology for the present and the future. Currently, platforms attempt to dominate a whole market. A platform with monopoly status can create its own rules, set prices, and collect data to manipulate consumers. Our team builds community driven, open source applications. Open Marketplace's development team is funded via donation and open grants. This funding model is used by Wikipedia, Linux, and Mozilla: current exemplars of production-ready nonprofit software. Our product enables communities to sell, share and communicate without a middleman, and includes privacy protection by design. Open Marketplace applications: an app store for smart cities!
 
-The final app submission form will go live shortly, keep your eyes on, *Slack*, *Twitter* and your email inbox for updates.
+The final app submission form will go live shortly, keep your eyes on, _Slack_, _Twitter_ and your email inbox for updates.
 
 Congratulations again to this week's winner, and thank you to everyone participating in the competition. Together we’re making a difference!
-


### PR DESCRIPTION
Without these quotes the `:` in the title confuses the blog as the `:` is also used to seperate the data from the property name.