### PR TITLE
Update website content to support final project submission form

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,14 @@ description: >
       <ul class="actions">
         <li>
           <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScWF9MhqdeMavKlrW77RXGW1upHgNc61wHMIoLkOOTb9soaGA/viewform?usp=sf_link"
+            class="button primary icon solid fa-external-link-alt"
+            target="_blank"
+            >Final Competition Submission</a
+          >
+        </li>
+        <li>
+          <a
             href="https://forms.gle/ApPc1ckSNdrSxWTH6"
             class="button primary icon solid fa-external-link-alt"
             target="_blank"

--- a/policies/final_form.txt
+++ b/policies/final_form.txt
@@ -1,0 +1,23 @@
+We've been blown away by the quality and imagination of the teams in this hackathon. After over a month of programming the date to submit your projects for final judging is here!
+
+You've got until April 30th at 23:59 UTC to submit your projects, and we're hoping to complete judging within the first two weeks of May with a virtual awards ceremony to follow. Watch Slack, Twitter and your email for details.
+
+If you haven't already, please take a look at the project submission pages, and check out the full rules while you're there. We've updated them over the last few days with new details on recording your pitch video, clearer explanations of the deliverables, and final prizes.
+
+https://codevid19.com/policies/submissions
+
+We've embedded a YouTube video below to help you get started with your pitch video, and have added lots of tips to the submission page.
+
+If you have questions, please reach out to the organizers on Slack by posting in #questions-for-organizers, or emails final-submissions@codevid19.com.
+
+We're also looking for more judges. If you know anyone that would make a good judge please share our application form which includes everything they need to know:
+
+https://forms.gle/ApPc1ckSNdrSxWTH6
+
+Note that email you enter below is used as the primary contact for your team. Please ensure someone is monitoring and able to answer questions from the judges during the first two weeks in May. We understand that people are in different timezones and a delay of up to 24-hours is understood, but quicker replies are appreciated!
+
+We'll send a copy of your project submission to the email below. Please review it and use the link supplied to update your entry if there are any mistakes.
+
+Good-luck and stay safe!
+
+~The CODEVID-19 Team

--- a/policies/rules.md
+++ b/policies/rules.md
@@ -91,6 +91,8 @@ Teams have until **Thursday, April 30th at 23:59 UTC** to submit their projects 
 
 Decided by a panel of expert judges, there are **8 prizes** up for grabs: 1 to a winner and 1 to a runner-up team in **each** of the **four [problem areas](rules#the-problems)**. Judging begins shortly after submission has closed. Although we aim to have judging wrap up within one week, we reserve the right to give our judges more time to evaluate the submissions.
 
+Like many things related to COVID-19 we've had to do things a little differently with this hackathon. In more conventional circumstances we'd have raised all prize money prior to the event. Instead, we've been actively working on your behalf to fundraise prize money during the course of this competition. The reality has been that with paperwork, busy lives, and wire transfer delays it takes longer than a month to get the money from sponsors and into our bank accounts. Anyone who's organized events like this will know this is normal, but to ensure sponsors have the required time to get funds to us we've set a deadline of May 31st at 23:59 UTC for funds to be received. After this we'll subtract expenses for running this event, keep a small reservce for unplanned expenses, and then divide the remainder amongst the winners. Should any funds remain, we'll donate them to a COVID-19 charity. With this in mind, we want teams to know that we won't start sending out prize money until June 2020 and will hope to get it done before the start of July 2020.
+
 ## Popular Choice Prize (1 in total)
 
 Similar to the weekly competitions, there will also be one final chance for the public to vote and award one team a prize at the end of the competition.

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -3,6 +3,10 @@ layout: default
 title: Submitting Your Project
 ---
 
+<ul class="actions stacked">
+  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLScWF9MhqdeMavKlrW77RXGW1upHgNc61wHMIoLkOOTb9soaGA/viewform?usp=sf_link" class="button primary fit">Final Submissions Open Now!!</a></li>
+</ul>
+
 ## Deliverables
 
 The following are all **required** unless stated otherwise.
@@ -25,6 +29,8 @@ Along with the [Deliverables](#deliverables) above, teams **must also include th
 - During final judging some teams may be asked to meet with the judges via video conference. Please ensure some or all team members are available.
 - Failure to communicate and answer questions from the judges may disadvantage your project's placement in the competition and could disqualify you from prizes.
 - Projects may only be submitted for consideration in one prize category at a time, however you can submit your project multiple times and apply for more than one prize.
+
+We want you to know that sponsors have until the end of May 2020 to deposit funds in our accounts. Prize amounts will be announced at the start of June once funds are received and we hope to get all **prizes out by the end of July 2020**. [Read the full rules for details.](./rules)
 
 ### Weekly Competition Submission
 

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -16,6 +16,16 @@ The following are all **required** unless stated otherwise.
 1. URL to your project on [FindCollabs](https://findcollabs.com/hackathon/codevid-19-isp21fkqtjupchx7kjed)
 1. **(Optional)** For open-source projects, we encourage a link to the source code repository (e.g. GitHub, GitLab, Bitbucket, etc.).
 
+### Final Competition Submission
+
+Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for final consideration:
+
+- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less, see ["Pitch Video"](#pitch-video) for details and hints**)
+- When submitting projects for final consideration, please ensure that the team is available during the judging period to answer questions about your project.
+- During final judging some teams may be asked to meet with the judges via video conference. Please ensure some or all team members are available.
+- Failure to communicate and answer questions from the judges may disadvantage your project's placement in the competition and could disqualify you from prizes.
+- Projects may only be submitted for consideration in one prize category at a time, however you can submit your project multiple times and apply for more than one prize.
+
 ### Weekly Competition Submission
 
 Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for weekly consideration:
@@ -28,16 +38,6 @@ Please remember:
 - Your submission does not need to be complete, but you must be able to demonstrate it.
 - Teams may submit their projects for multiple weekly considerations; however, new progress must be demonstrated leading up to each submission.
 - Be sure to review the [Deliverables](#deliverables) and have them ready before we close submissions!
-
-### Final Competition Submission
-
-Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for final consideration:
-
-- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less, see ["Pitch Video"](#pitch-video) for details and hints**)
-- When submitting projects for final consideration, please ensure that the team is available during the judging period to answer questions about your project.
-- During final judging some teams may be asked to meet with the judges via video conference. Please ensure some or all team members are available.
-- Failure to communicate and answer questions from the judges may disadvantage your project's placement in the competition and could disqualify you from prizes.
-- Projects may only be submitted for consideration in one prize category at a time, however you can submit your project multiple times and apply for more than one prize.
 
 ## Pitch Video
 

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -23,6 +23,8 @@ Along with the [Deliverables](#deliverables) above, teams **must also include th
 1. Long description/pitch for your app we can use to describe your app to voters, judges, and the media.
 1. Instructions for interacting with your app (if not included in the app itself).
 
+Please remember:
+
 - Your submission does not need to be complete, but you must be able to demonstrate it.
 - Teams may submit their projects for multiple weekly considerations; however, new progress must be demonstrated leading up to each submission.
 - Be sure to review the [Deliverables](#deliverables) and have them ready before we close submissions!
@@ -31,14 +33,13 @@ Along with the [Deliverables](#deliverables) above, teams **must also include th
 
 Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for final consideration:
 
-- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less**)
-  - Look at the ["Pitch Video"](#pitch-video) section below for details and hints on the video
+- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less, see ["Pitch Video"](#pitch-video) for details and hints**)
 - When submitting projects for final consideration, please ensure that the team is available during the judging period to answer questions about your project.
 - During final judging some teams may be asked to meet with the judges via video conference. Please ensure some or all team members are available.
 - Failure to communicate and answer questions from the judges may disadvantage your project's placement in the competition and could disqualify you from prizes.
 - Projects may only be submitted for consideration in one prize category at a time, however you can submit your project multiple times and apply for more than one prize.
 
-### Pitch Video
+## Pitch Video
 
 We've prepared a short video (under 3 minutes!) that both explains what you should do in your pitch video, and serves as an example of the type of video we're looking for. [Read the slides I shared in the video](https://docs.google.com/presentation/d/1KsrRGj08XK-x3RKgTIdWszW2jqMSmqdLFCTlsT8l3Xw/edit?usp=sharing).
 
@@ -46,13 +47,13 @@ We've prepared a short video (under 3 minutes!) that both explains what you shou
 
 The key takeaways are:
 
-1. Pretend you're talking to a room full of judges at the end of a in-person hackathon.
+1. Pretend you're talking to a room full of judges at the end of an in-person hackathon.
 1. Don't worry about production quality. Focus on being clear, and convincing.
 1. You don't need to speak or use a webcam, subtitles or descriptive text are ok. The judges understand that English is not everyone's first language.
 1. If you do use a webcam and microphone please try to use proper lighting and a quality external microphone or headset. Stand up while you speak if possible.
 1. Record mobile apps using a simulator on your desktop or the recorder on your device.
 1. Open Broadcaster Studio is a great cross platform recording tool, but Mac and Windows have screen recording built in as well.
-1. Only PUBLIC or UNLISTED YouTube videos under 3 minutes that don't require signing in to view will be accepted
+1. Only [PUBLIC or UNLISTED YouTube videos](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) under 3 minutes that don't require signing in to view will be accepted
 
 In terms of content please make sure you:
 

--- a/policies/submissions.md
+++ b/policies/submissions.md
@@ -11,14 +11,17 @@ The following are all **required** unless stated otherwise.
 1. URL to your working app (the website, or a TestFlight/Google Play opt-in link).
 1. URL to a screenshot we can share with voters and the media.
 1. The [CODEVID-19 problem](rules#the-problems) you're addressing.
-1. Short description/pitch for your app we can share on Twitter and social media (140 characters or less)
-1. Long description/pitch for your app we can use to describe your app to voters, judges, and the media.
-1. Instructions for interacting with your app (if not included in the app itself).
+1. A short pitch that explains your project and how it effectively solves the problem it's trying to address, along with how you make it accessible to as many people as possible, and the number of people it's impacted. (260 characters or less)
 1. An email address that judges can contact should they have questions or concerns. This email will **not** be shared publicly.
 1. URL to your project on [FindCollabs](https://findcollabs.com/hackathon/codevid-19-isp21fkqtjupchx7kjed)
 1. **(Optional)** For open-source projects, we encourage a link to the source code repository (e.g. GitHub, GitLab, Bitbucket, etc.).
 
 ### Weekly Competition Submission
+
+Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for weekly consideration:
+
+1. Long description/pitch for your app we can use to describe your app to voters, judges, and the media.
+1. Instructions for interacting with your app (if not included in the app itself).
 
 - Your submission does not need to be complete, but you must be able to demonstrate it.
 - Teams may submit their projects for multiple weekly considerations; however, new progress must be demonstrated leading up to each submission.
@@ -28,11 +31,35 @@ The following are all **required** unless stated otherwise.
 
 Along with the [Deliverables](#deliverables) above, teams **must also include the following** when submitting for final consideration:
 
-- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less**) that clearly explains:
-  1. The problem being solved
-  1. How to use the app
-  1. Any unique features or information pertinent to the judging
+- A **[public/unlisted](https://support.google.com/youtube/answer/157177?co=GENIE.Platform%3DDesktop&hl=en) YouTube URL** to your pitch and demo (**3 minutes or less**)
+  - Look at the ["Pitch Video"](#pitch-video) section below for details and hints on the video
 - When submitting projects for final consideration, please ensure that the team is available during the judging period to answer questions about your project.
 - During final judging some teams may be asked to meet with the judges via video conference. Please ensure some or all team members are available.
 - Failure to communicate and answer questions from the judges may disadvantage your project's placement in the competition and could disqualify you from prizes.
 - Projects may only be submitted for consideration in one prize category at a time, however you can submit your project multiple times and apply for more than one prize.
+
+### Pitch Video
+
+We've prepared a short video (under 3 minutes!) that both explains what you should do in your pitch video, and serves as an example of the type of video we're looking for. [Read the slides I shared in the video](https://docs.google.com/presentation/d/1KsrRGj08XK-x3RKgTIdWszW2jqMSmqdLFCTlsT8l3Xw/edit?usp=sharing).
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rA1y1oKQ4a4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+The key takeaways are:
+
+1. Pretend you're talking to a room full of judges at the end of a in-person hackathon.
+1. Don't worry about production quality. Focus on being clear, and convincing.
+1. You don't need to speak or use a webcam, subtitles or descriptive text are ok. The judges understand that English is not everyone's first language.
+1. If you do use a webcam and microphone please try to use proper lighting and a quality external microphone or headset. Stand up while you speak if possible.
+1. Record mobile apps using a simulator on your desktop or the recorder on your device.
+1. Open Broadcaster Studio is a great cross platform recording tool, but Mac and Windows have screen recording built in as well.
+1. Only PUBLIC or UNLISTED YouTube videos under 3 minutes that don't require signing in to view will be accepted
+
+In terms of content please make sure you:
+
+1. Clearly say the name of your project and how to access it
+1. Explain the problem you're solving and which problem area you're competing in
+1. Explain how your project effectively solves your problem
+1. Explain how your project has been made accessible to as many people as possible
+1. Explain the impact your project has had (people helped to date, lives saved, businesses, etc.)
+1. Ideally, your project should be easy enough to use that it doesn't require directions but if it does please demonstrate for the judges.
+1. At the end mention again how to try your app and how to get help from your team


### PR DESCRIPTION
I've taken a lot of content that was previously in the final project submission form and moved it over to the website.

Note to @ajyong and @MandyMeindersma that I'm bad at dates and said sponsors had until May 30th to get us funds, with money going out in June. May ends of the 31st so this PR reflects that. ;)