### PR TITLE
Embed the shared calendar on the landing page

### DIFF
--- a/_sass/components/_calendar.scss
+++ b/_sass/components/_calendar.scss
@@ -1,0 +1,6 @@
+/* Calendar IFrame */
+
+.calendar {
+  width: 100%;
+  height: 640px;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -57,6 +57,7 @@
 @import "components/row";
 @import "components/box";
 @import "components/button";
+@import "components/calendar";
 @import "components/features";
 @import "components/form";
 @import "components/icon";

--- a/index.html
+++ b/index.html
@@ -89,9 +89,28 @@ description: >
   <section id="calendar" class="wrapper style3 fade-up">
     <div class="inner">
       <h2>Calendar</h2>
+      <p>
+        <strong>Note:</strong> Times are in UTC,
+        <a
+          href="https://calendar.google.com/event?action=TEMPLATE&tmeid=NWY3b2E1MWNnamxrdm83am04b2VwanA3aHMgZGV2ZWRtb250b24uY29tX2Z0OG5vY2w1Y285Nzk1MHQ3a2ExcTRicm04QGc&tmsrc=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
+          target="_blank"
+        >
+          add to your calendar
+          <span class="icon solid fa-external-link-alt"></span
+        ></a>
+        or
+        <a
+          href="https://www.timeanddate.com/worldclock/converter.html"
+          target="_blank"
+        >
+          use a time zone converter
+          <span class="icon solid fa-external-link-alt"></span
+        ></a>
+        to get events in your local time.
+      </p>
       <iframe
         class="calendar"
-        src="https://calendar.google.com/calendar/embed?src=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
+        src="https://calendar.google.com/calendar/embed?wkst=1&amp;bgcolor=%23b74e91&amp;ctz=UTC&amp;showTz=1&amp;showTitle=0&amp;showDate=1&amp;showPrint=1&amp;showTabs=1&amp;showCalendars=0&amp;src=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
         frameborder="0"
       ></iframe>
     </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@ description: >
             see-->
         <li><a href="#intro">Welcome</a></li>
         <li>
+          <a href="#calendar">Calendar</a>
+        </li>
+        <li>
           <a href="#rules-and-faq">Rules & FAQ</a>
         </li>
         <li><a href="#links">Links & Resources</a></li>
@@ -79,6 +82,18 @@ description: >
           >
         </li>
       </ul>
+    </div>
+  </section>
+
+  <!-- Calendar -->
+  <section id="calendar" class="wrapper style3 fade-up">
+    <div class="inner">
+      <h2>Calendar</h2>
+      <iframe
+        class="calendar"
+        src="https://calendar.google.com/calendar/embed?src=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
+        frameborder="0"
+      ></iframe>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ description: >
       <p>
         <strong>Note:</strong> Times are in UTC,
         <a
-          href="https://calendar.google.com/event?action=TEMPLATE&tmeid=NWY3b2E1MWNnamxrdm83am04b2VwanA3aHMgZGV2ZWRtb250b24uY29tX2Z0OG5vY2w1Y285Nzk1MHQ3a2ExcTRicm04QGc&tmsrc=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
+          href="https://calendar.google.com/calendar/b/4?cid=ZGV2ZWRtb250b24uY29tX2Z0OG5vY2w1Y285Nzk1MHQ3a2ExcTRicm04QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
           target="_blank"
         >
           add to your calendar

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ description: >
       </p>
       <iframe
         class="calendar"
-        src="https://calendar.google.com/calendar/embed?wkst=1&amp;bgcolor=%23b74e91&amp;ctz=UTC&amp;showTz=1&amp;showTitle=0&amp;showDate=1&amp;showPrint=1&amp;showTabs=1&amp;showCalendars=0&amp;src=devedmonton.com_ft8nocl5co97950t7ka1q4brm8%40group.calendar.google.com"
+        src="https://calendar.google.com/calendar/embed?wkst=1&amp;bgcolor=%23b74e91&amp;ctz=UTC&amp;showTz=1&amp;showTitle=0&amp;showDate=1&amp;showPrint=1&amp;showTabs=1&amp;showCalendars=0&amp;src=ZGV2ZWRtb250b24uY29tX2Z0OG5vY2w1Y285Nzk1MHQ3a2ExcTRicm04QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
         frameborder="0"
       ></iframe>
     </div>


### PR DESCRIPTION
This should make it easier for everyone to know when things are happening.  ~~What I'm not sure about is whether this calendar is locked to Mountain time.  I made sure the embed URL wasn't specifying a time zone but I haven't tested it in other zones.~~

Thanks to @MandyMeindersma's investigation I've updated it to denote UTC, the embed doesn't dynamically change the time zone based on the client.

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/6334517/80324061-0e4a3f80-87ec-11ea-8977-34fbec9b36f2.png">
