### PR TITLE
Fix blockquotes in blog

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -171,6 +171,10 @@ blockquote {
   margin: 0 0 _size(element-margin) 0;
   padding: (_size(element-margin) / 4) 0 (_size(element-margin) / 4)
     _size(element-margin);
+
+  p {
+    margin: 0;
+  }
 }
 
 code {


### PR DESCRIPTION
### Before
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/6334517/80326024-b401ac80-87f4-11ea-8de6-ddb6f8e81ace.png">

### After
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/6334517/80326006-a2b8a000-87f4-11ea-82d9-7bd457529b78.png">

Root cause was the Markdown to HTML conversion adds a `<p>` tag inside the blockquote's text, whereas this HTML5UP template was not made for that.